### PR TITLE
add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Continuous integration
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+  workflow_dispatch: # allows manual triggering
+env:
+  # Bump this number to invalidate the GH actions cache
+  cache-version: 0
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        ghc: ['90', '92']
+        os: ['ubuntu-latest', 'macos-latest']
+    runs-on: ${{ matrix.os }}
+    name: Build with GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixos-22.11
+    - name: Build
+      run: nix build -L .#crm.ghc${{ matrix.ghc }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist-*
 
 # nix
 result
+result-*
 
 # direnv
 .direnv

--- a/flake.nix
+++ b/flake.nix
@@ -103,12 +103,12 @@
               cabal-install
               fourmolu
               haskell-language-server
-              hpack
               build-watch
               test-watch
-              pkgs.fd
-              pkgs.entr
               pkgs.bat
+              pkgs.entr
+              pkgs.fd
+              pkgs.hpack
             ];
             shellHook = ''
               export PS1="❄️ GHC ${haskellPackages.ghc.version} $PS1"

--- a/package.yaml
+++ b/package.yaml
@@ -99,6 +99,11 @@ library:
   source-dirs:      src
   dependencies:
     - profunctors
+  # Disable adding Paths_crm to other-modules, because it does not conform to our style guide.
+  # https://github.com/sol/hpack#handling-of-paths_-modules
+  when:
+  - condition: false
+    other-modules: Paths_crm
 
 tests:
   crm-spec:
@@ -107,3 +112,6 @@ tests:
     dependencies:
       - crm
       - hspec
+    when:
+    - condition: false
+      other-modules: Paths_crm


### PR DESCRIPTION
The workflow tests each supported GHC version on each supported operating system (Linux and macOS).

It should trigger on every commit and PR to `main`.

Note that `nix build` also runs the test suite.

Closes #5

This PR should be merged after #9, which fixes one of the compilation errors on GHC 9.2.